### PR TITLE
feat: add Empty struct conforming to PDFDrawable protocol

### DIFF
--- a/Sources/PDFDrawable/Empty.swift
+++ b/Sources/PDFDrawable/Empty.swift
@@ -1,0 +1,16 @@
+//
+//  Empty.swift
+//  PDFDrawable
+//
+//  Created by Daniel Tartaglia on 15 Feb 2024.
+//  Copyright © 2024 Daniel Tartaglia. MIT License.
+//
+
+import Foundation
+import PDFKit
+
+public struct Empty: PDFDrawable {
+    public let size = CGSize.zero
+
+    public func draw(context _: UIGraphicsPDFRendererContext, origin _: CGPoint) { }
+}


### PR DESCRIPTION
The Empty struct is added to the PDFDrawable module. It conforms to the PDFDrawable protocol and provides an empty implementation for the draw method. The size property is set to CGSize.zero. This struct can be used as a placeholder or initial value in reducers.